### PR TITLE
[Feature/loginout] 홈페이지에서 로그인 아웃에따른 메뉴 구분 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,16 +20,21 @@ import Password2 from "./components/pages/Password2";
 import Password3 from "./components/pages/Password3";
 import Meeting2 from "./components/pages/Meeting2";
 import Meeting3 from "./components/pages/Meeting3";
+import { useState } from "react";
 
 // SPA 추후 무조건 개선해야함
 
 function App() {
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
+
   return (
     <>
       <BrowserRouter>
-        <Navbar />
+        <Navbar isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />
         <Switch>
-          <Route path="/" exact component={Main} />
+          <Route path="/" exact>
+            <Main isLoggedIn={isLoggedIn} />
+          </Route>
           <Route path="/menu" component={Menu} />
           <Route path="/about" component={About} />
           <Route path="/setting" component={Setting} />

--- a/src/components/pages/Main.jsx
+++ b/src/components/pages/Main.jsx
@@ -4,9 +4,9 @@ import Calendar from "./../ui/organisms/Calendar";
 import moment from "moment";
 import BottomButton from "../ui/organisms/BottomButton";
 
-const Main = () => {
+const Main = (props) => {
   const history = useHistory();
-
+  const { isLoggedIn } = props;
   const [selectedDate, setSelectedDate] = useState({
     startDate: null,
     endDate: null,
@@ -25,7 +25,13 @@ const Main = () => {
   return (
     <>
       <div className="m-4 mt-20">
-        <h1 className="mt-8 text-2xl font-bold">반가워요 👋</h1>
+        {isLoggedIn ? (
+          <h1 className="mt-8 text-2xl font-bold">
+            <span className="text-blue-400">오구오구</span>님 👋
+          </h1>
+        ) : (
+          <h1 className="mt-8 text-2xl font-bold">반가워요 👋</h1>
+        )}
         <h1 className="mt-3 text-2xl font-bold">
           모임이 가능한
           <br />

--- a/src/components/ui/organisms/Navbar.jsx
+++ b/src/components/ui/organisms/Navbar.jsx
@@ -3,12 +3,14 @@ import { Link } from "react-router-dom";
 import { FaBars } from "react-icons/fa";
 import { BsX, BsChevronRight } from "react-icons/bs";
 
-const Navbar = () => {
+const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
   const [sidebar, setSidebar] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(true);
+
   const showSidebar = () => setSidebar(!sidebar);
   const handleLogout = () => {
-    setIsLoggedIn(!isLoggedIn);
+    setTimeout(() => {
+      setIsLoggedIn(!isLoggedIn);
+    }, 800);
   };
 
   return (
@@ -33,7 +35,8 @@ const Navbar = () => {
             {isLoggedIn ? (
               <>
                 <h1 className="mt-8 text-xl font-bold">
-                  오구오구 님<br />
+                  <span className="text-blue-400">오구오구 </span>님
+                  <br />
                   반가워요!
                 </h1>
                 <p className="mt-4 mb-8 text-gray-500 text-sm">
@@ -127,7 +130,14 @@ const Navbar = () => {
               </div>
             </Link>
           </li>
-
+          {isLoggedIn && (
+            <p
+              onClick={handleLogout}
+              className="mx-8 cursor-pointer mt-28 text-sm text-gray-500 underline"
+            >
+              로그아웃
+            </p>
+          )}
           {/* <Link to="/profile" onClick={showSidebar}>
             <div className="m-8 mt-16">
               <h1 className="mt-8 text-2xl font-bold font-">

--- a/src/components/ui/organisms/Navbar.jsx
+++ b/src/components/ui/organisms/Navbar.jsx
@@ -5,8 +5,11 @@ import { BsX, BsChevronRight } from "react-icons/bs";
 
 const Navbar = () => {
   const [sidebar, setSidebar] = useState(false);
-
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
   const showSidebar = () => setSidebar(!sidebar);
+  const handleLogout = () => {
+    setIsLoggedIn(!isLoggedIn);
+  };
 
   return (
     <>
@@ -27,13 +30,31 @@ const Navbar = () => {
           </li>
 
           <div className="m-8 mt-16">
-            <img className="mt-8 w-12" src="images/LogoIcon.png" alt="MOIDA" />
+            {isLoggedIn ? (
+              <>
+                <h1 className="mt-8 text-xl font-bold">
+                  오구오구 님<br />
+                  반가워요!
+                </h1>
+                <p className="mt-4 mb-8 text-gray-500 text-sm">
+                  moida@gmail.com
+                </p>
+              </>
+            ) : (
+              <>
+                <img
+                  className="mt-8 w-12"
+                  src="images/LogoIcon.png"
+                  alt="MOIDA"
+                />
+                <p className="mt-4 mb-8 text-gray-500 text-sm">
+                  <span className="font-bold">로그인</span>하시면 모이다를
+                  <br />
+                  편리하게 이용하실 수 있어요!
+                </p>
+              </>
+            )}
 
-            <p className="mt-4 mb-8 text-gray-500 text-sm">
-              <span className="font-bold">로그인</span>하시면 모이다를
-              <br />
-              편리하게 이용하실 수 있어요!
-            </p>
             <Link
               to="/create"
               className="p-3 flex border bg-moida border-moida rounded-md text-white font-medium"
@@ -43,24 +64,38 @@ const Navbar = () => {
           </div>
 
           <hr className="m-8" />
+          {isLoggedIn ? (
+            <>
+              <li className="mx-8 my-6" onClick={showSidebar}>
+                <Link to="/join">
+                  <div className="flex justify-between items-center">
+                    <p className="font-medium">모임 관리</p>
+                    <BsChevronRight />
+                  </div>
+                </Link>
+              </li>
+            </>
+          ) : (
+            <>
+              <li className="mx-8 my-6" onClick={showSidebar}>
+                <Link to="/login">
+                  <div className="flex justify-between items-center">
+                    <p className="font-medium">로그인</p>
+                    <BsChevronRight />
+                  </div>
+                </Link>
+              </li>
 
-          <li className="mx-8 my-6" onClick={showSidebar}>
-            <Link to="/login">
-              <div className="flex justify-between items-center">
-                <p className="font-medium">로그인</p>
-                <BsChevronRight />
-              </div>
-            </Link>
-          </li>
-
-          <li className="mx-8 my-6" onClick={showSidebar}>
-            <Link to="/join">
-              <div className="flex justify-between items-center">
-                <p className="font-medium">회원가입</p>
-                <BsChevronRight />
-              </div>
-            </Link>
-          </li>
+              <li className="mx-8 my-6" onClick={showSidebar}>
+                <Link to="/join">
+                  <div className="flex justify-between items-center">
+                    <p className="font-medium">회원가입</p>
+                    <BsChevronRight />
+                  </div>
+                </Link>
+              </li>
+            </>
+          )}
 
           <hr className="m-8" />
 


### PR DESCRIPTION
resolved #53 

## Description

- 로그인 비로그인 상태일때의 메인페이지 구분 

## Progress

- [x] 비로그인 상태일때의 메뉴 구성
- [x] 로그인 상태일때의 메뉴 구성
- [x] 로그아웃시 메뉴,레이아웃 변경 

## Screenshot
![로그인아웃](https://user-images.githubusercontent.com/53388557/129568654-3829b05f-27a0-4c1d-82b0-19ede110adb9.gif)

## Comments

- 발표 시나리오 구현 
