### PR TITLE
[Feature/result-page] 일정 결과 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import Meeting2 from "./components/pages/Meeting2";
 import Meeting3 from "./components/pages/Meeting3";
 import { useState } from "react";
 import Result from "./components/pages/Result";
+import ResultDetail from "./components/pages/ResultDetail";
 
 // SPA 추후 무조건 개선해야함
 
@@ -54,6 +55,7 @@ function App() {
           <Route path="/meeting2" component={Meeting2} />
           <Route path="/meeting3" component={Meeting3} />
           <Route path="/manage" component={Manage} />
+          <Route path="/result/:id/detail" component={ResultDetail} />
           <Route path="/result/:id" component={Result} />
         </Switch>
       </BrowserRouter>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import Password3 from "./components/pages/Password3";
 import Meeting2 from "./components/pages/Meeting2";
 import Meeting3 from "./components/pages/Meeting3";
 import { useState } from "react";
+import Result from "./components/pages/Result";
 
 // SPA 추후 무조건 개선해야함
 
@@ -53,6 +54,7 @@ function App() {
           <Route path="/meeting2" component={Meeting2} />
           <Route path="/meeting3" component={Meeting3} />
           <Route path="/manage" component={Manage} />
+          <Route path="/result/:id" component={Result} />
         </Switch>
       </BrowserRouter>
     </>

--- a/src/components/pages/Result.jsx
+++ b/src/components/pages/Result.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import { Link, useHistory, useLocation } from "react-router-dom";
+import BottomButton from "../ui/organisms/BottomButton";
+import { FaRegCalendarAlt } from "react-icons/fa";
+import { BsClock } from "react-icons/bs";
+const Result = (props) => {
+  const [meetingInfo, setMeetingInfo] = useState({ a: true });
+  const history = useHistory();
+  console.log(meetingInfo);
+
+  const handleViewDetail = () => {};
+  useEffect(() => {
+    const meetingId = props.match.params.id;
+
+    axios
+      .get(`/meetings/${meetingId}`)
+      .then((response) => {
+        const data = response.data.data;
+        setMeetingInfo(data.meeting);
+      })
+      .catch(() => {
+        history.push("/");
+      });
+  }, []);
+
+  return (
+    meetingInfo && (
+      <div className="block w-full h-screen bg-gray-50">
+        <div className="mx-8">
+          <h1 className="pt-16 text-3xl font-bold mb-16">
+            짜잔 ✨
+            <br />
+            모임 일정 결과를
+            <br />
+            확인해보세요.
+          </h1>
+
+          <div className="w-full h-96 bg-white rounded-xl shadow-md">
+            <div className="mx-8">
+              <div className="flex justify-between items-center pt-12">
+                <div className="flex items-center">
+                  <p className="text-xl font-bold">{meetingInfo.title}</p>
+                  <p className="text-xs mx-2 font-light text-white bg-yellow-400 p-1 px-2 rounded-xl">
+                    진행중
+                  </p>
+                </div>
+
+                <div className="flex ml-2 text-xl"></div>
+              </div>
+              <hr className="w-full my-4 " />
+
+              <ul>
+                <li className="flex  items-center py-4">
+                  <FaRegCalendarAlt />
+                  <span className="ml-10">8월 2일 월요일 ~ 8월 5일 목요일</span>
+                </li>
+                <li className="flex  items-center py-4">
+                  <BsClock />
+                  <span className="ml-10">오후 2:00 ~ 오후 10:00</span>
+                </li>
+                <li className="flex  items-center py-4">
+                  <BsClock />
+                  <span className="ml-10">출발 위치: 잠실역</span>
+                </li>
+              </ul>
+              <button className="mt-6 border-2 rounded p-3 border-blue-300 text-blue-300 w-full flex justify-center items-center">
+                모임 내용 상세보기
+              </button>
+            </div>
+            {/* <div className="my-8" />
+
+            <div className="flex justify-between items-center mx-4">
+              <div className="flex items-center">
+                <p className="text-xl font-bold">
+                  진행중인 모임 {meetingInfo.title}
+                </p>
+                <p className="text-xs mx-2 font-light text-white bg-yellow-400 p-1 px-2 rounded-xl">
+                  진행중
+                </p>
+              </div>
+              <div className="flex ml-2 text-xl"></div>
+            </div>
+
+            <p className="text-sm font-light text-gray-400 my-2 mx-4">
+              {meetingInfo.description} 진행중
+            </p>
+
+            <hr /> */}
+          </div>
+
+          <BottomButton onClinck={handleViewDetail}>확인</BottomButton>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default Result;

--- a/src/components/pages/Result.jsx
+++ b/src/components/pages/Result.jsx
@@ -9,7 +9,6 @@ const Result = (props) => {
   const history = useHistory();
   console.log(meetingInfo);
 
-  const handleViewDetail = () => {};
   useEffect(() => {
     const meetingId = props.match.params.id;
 
@@ -64,32 +63,16 @@ const Result = (props) => {
                   <span className="ml-10">출발 위치: 잠실역</span>
                 </li>
               </ul>
-              <button className="mt-6 border-2 rounded p-3 border-blue-300 text-blue-300 w-full flex justify-center items-center">
-                모임 내용 상세보기
-              </button>
+              <Link to={`/result/${props.match.params.id}/detail`}>
+                <button className="mt-6 border-2 rounded p-3 border-blue-300 text-blue-300 w-full flex justify-center items-center">
+                  모임 내용 상세보기
+                </button>
+              </Link>
             </div>
-            {/* <div className="my-8" />
-
-            <div className="flex justify-between items-center mx-4">
-              <div className="flex items-center">
-                <p className="text-xl font-bold">
-                  진행중인 모임 {meetingInfo.title}
-                </p>
-                <p className="text-xs mx-2 font-light text-white bg-yellow-400 p-1 px-2 rounded-xl">
-                  진행중
-                </p>
-              </div>
-              <div className="flex ml-2 text-xl"></div>
-            </div>
-
-            <p className="text-sm font-light text-gray-400 my-2 mx-4">
-              {meetingInfo.description} 진행중
-            </p>
-
-            <hr /> */}
           </div>
-
-          <BottomButton onClinck={handleViewDetail}>확인</BottomButton>
+          <Link to={`/result/${props.match.params.id}/detail`}>
+            <BottomButton>확인</BottomButton>
+          </Link>
         </div>
       </div>
     )

--- a/src/components/pages/ResultDetail.jsx
+++ b/src/components/pages/ResultDetail.jsx
@@ -5,26 +5,33 @@ import { FaEllipsisV } from "react-icons/fa";
 
 const ResultDetail = (props) => {
   const [meetingInfo, setMeetingInfo] = useState({ a: true });
+  const [toggle, setToggle] = useState(true);
   const history = useHistory();
   useEffect(() => {
     const meetingId = props.match.params.id;
 
-    // axios
-    //   .get(`/meetings/${meetingId}`)
-    //   .then((response) => {
-    //     const data = response.data.data;
-    //     setMeetingInfo(data.meeting);
-    //   })
-    //   .catch(() => {
-    //     history.push("/");
-    //   });
+    axios
+      .get(`/meetings/${meetingId}`)
+      .then((response) => {
+        const data = response.data.data;
+        setMeetingInfo(data.meeting);
+      })
+      .catch(() => {
+        history.push("/");
+      });
   }, []);
-
+  const handleToggle = (event) => {
+    console.log(event);
+    const { result } = event.target.dataset;
+    console.log(result);
+    if (result === "time") setToggle(true);
+    else setToggle(false);
+  };
   return (
     meetingInfo && (
       <div className="block w-full h-screen bg-gray-50">
         <div className="mx-8">
-          <h1 className="pt-16 text-3xl font-bold mb-16">
+          <h1 className="pt-16 text-3xl font-bold mb-10">
             짜잔 ✨
             <br />
             모임 일정 결과를
@@ -57,84 +64,111 @@ const ResultDetail = (props) => {
           <div className="mt-8 mb-4 border-4 border-gray-100"></div>
         </div>
         <div className="grid grid-cols-2">
-          <div>
-            <p className="text-center text-gray-300">text</p>
-            <hr className="mt-4 border" />
+          <div
+            onClick={handleToggle}
+            data-result="time"
+            className="cursor-pointer"
+          >
+            <p
+              data-result="time"
+              className={`text-center ${
+                toggle ? "text-blue-400" : "text-gray-300"
+              }`}
+            >
+              날짜&시간 결과보기
+            </p>
+            <hr className={`mt-4 border ${toggle && "border-blue-400"}`} />
           </div>
 
-          <div>
-            <p className="text-center text-blue-400">text</p>
-            <hr className="mt-4 border -blue-400 border-blue-400" />
+          <div
+            onClick={handleToggle}
+            data-result="place"
+            className="cursor-pointer"
+          >
+            <p
+              data-result="place"
+              className={`text-center ${
+                toggle ? "text-gray-300" : "text-blue-400"
+              }`}
+            >
+              장소 결과 보기
+            </p>
+            <hr className={`mt-4 border ${!toggle && "border-blue-400"}`} />
           </div>
         </div>
 
         {/* 날짜로 보기  */}
-        <div>
-          <h2>날짜로 보기 </h2>
-        </div>
+        {toggle && (
+          <>
+            <div className="bg-white">
+              <h2>날짜로 보기 </h2>
+              <h1>시간표 처리..시나리오대로 그리기</h1>
 
-        {/* 멤버 보기  */}
+              {/* 멤버 보기  */}
 
-        <div className="mt-8 mb-4 border-4 border-gray-100"></div>
+              <div className="mt-8 mb-4 border-4 border-gray-100"></div>
 
-        <div className="m-4 mt-4">
-          <h2 className="mt-8 text-lg font-bold">
-            참석 멤버 <span className="font-normal">(6명 참여)</span>
-          </h2>
+              <div className="m-4 mt-4 bg-white">
+                <h2 className="mt-8 text-lg font-bold">
+                  참석 멤버 <span className="font-normal">(6명 참여)</span>
+                </h2>
 
-          <div className="mt-4 p-4 w-full shadow-2xl rounded-xl">
-            <div className="grid grid-cols-2">
-              <div className="ml-4">
-                <h3 className="my-6 font-bold">
-                  가능해요 <span className="text-green-500">4</span>
-                </h3>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-red-200 w-8 h-8 mr-2 rounded-full">
-                    😺
-                  </div>
-                  <div className="h-4 w-4 -ml-5 -mb-4 rounded-full bg-moida"></div>
-                  <p className="ml-1 font-bold">소석진 (나)</p>
-                </div>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-yellow-200 w-8 h-8 mr-2 rounded-full">
-                    🎀
-                  </div>
-                  <p>하영이</p>
-                </div>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-yellow-300 w-8 h-8 mr-2 rounded-full">
-                    ⚽
-                  </div>
-                  <p>경후니</p>
-                </div>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-green-200 w-8 h-8 mr-2 rounded-full">
-                    🍩
-                  </div>
-                  <p>이혀니</p>
-                </div>
-              </div>
+                <div className="mt-4 p-4 w-full shadow-2xl rounded-xl">
+                  <div className="grid grid-cols-2">
+                    <div className="ml-4">
+                      <h3 className="my-6 font-bold">
+                        가능해요 <span className="text-green-500">4</span>
+                      </h3>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-red-200 w-8 h-8 mr-2 rounded-full">
+                          😺
+                        </div>
+                        <div className="h-4 w-4 -ml-5 -mb-4 rounded-full bg-moida"></div>
+                        <p className="ml-1 font-bold">소석진 (나)</p>
+                      </div>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-yellow-200 w-8 h-8 mr-2 rounded-full">
+                          🎀
+                        </div>
+                        <p>하영이</p>
+                      </div>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-yellow-300 w-8 h-8 mr-2 rounded-full">
+                          ⚽
+                        </div>
+                        <p>경후니</p>
+                      </div>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-green-200 w-8 h-8 mr-2 rounded-full">
+                          🍩
+                        </div>
+                        <p>이혀니</p>
+                      </div>
+                    </div>
 
-              <div className="ml-4">
-                <h3 className="my-6 font-bold">
-                  불가능해요 <span className="text-red-500">2</span>
-                </h3>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-blue-300 w-8 h-8 mr-2 rounded-full">
-                    🌹
+                    <div className="ml-4">
+                      <h3 className="my-6 font-bold">
+                        불가능해요 <span className="text-red-500">2</span>
+                      </h3>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-blue-300 w-8 h-8 mr-2 rounded-full">
+                          🌹
+                        </div>
+                        <p>람이</p>
+                      </div>
+                      <div className="flex items-center mb-4">
+                        <div className="flex justify-center items-center bg-indigo-400 w-8 h-8 mr-2 rounded-full">
+                          🥑
+                        </div>
+                        <p>서하서하</p>
+                      </div>
+                    </div>
                   </div>
-                  <p>람이</p>
-                </div>
-                <div className="flex items-center mb-4">
-                  <div className="flex justify-center items-center bg-indigo-400 w-8 h-8 mr-2 rounded-full">
-                    🥑
-                  </div>
-                  <p>서하서하</p>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          </>
+        )}
       </div>
     )
   );

--- a/src/components/pages/ResultDetail.jsx
+++ b/src/components/pages/ResultDetail.jsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router";
+import axios from "axios";
+import { FaEllipsisV } from "react-icons/fa";
+
+const ResultDetail = (props) => {
+  const [meetingInfo, setMeetingInfo] = useState({ a: true });
+  const history = useHistory();
+  useEffect(() => {
+    const meetingId = props.match.params.id;
+
+    // axios
+    //   .get(`/meetings/${meetingId}`)
+    //   .then((response) => {
+    //     const data = response.data.data;
+    //     setMeetingInfo(data.meeting);
+    //   })
+    //   .catch(() => {
+    //     history.push("/");
+    //   });
+  }, []);
+
+  return (
+    meetingInfo && (
+      <div className="block w-full h-screen bg-gray-50">
+        <div className="mx-8">
+          <h1 className="pt-16 text-3xl font-bold mb-16">
+            짜잔 ✨
+            <br />
+            모임 일정 결과를
+            <br />
+            확인해보세요.
+          </h1>
+        </div>
+        <div className="sticky top-0 bg-white">
+          <hr className="my-8" />
+
+          <div className="flex justify-between items-center mx-4">
+            <div className="flex items-center">
+              <p className="text-xl font-bold">{meetingInfo.title}</p>
+              <p className="text-xs mx-2 font-light text-white bg-yellow-400 p-1 px-2 rounded-xl">
+                진행중
+              </p>
+            </div>
+            <div className="flex ml-2 text-xl">
+              <FaEllipsisV
+                className="cursor-pointer"
+                // onClick={handleShareButtonClick}
+              />
+            </div>
+          </div>
+
+          <p className="text-sm font-light text-gray-400 my-2 mx-4">
+            dd{meetingInfo.description}
+          </p>
+
+          <div className="mt-8 mb-4 border-4 border-gray-100"></div>
+        </div>
+        <div className="grid grid-cols-2">
+          <div>
+            <p className="text-center text-gray-300">text</p>
+            <hr className="mt-4 border" />
+          </div>
+
+          <div>
+            <p className="text-center text-blue-400">text</p>
+            <hr className="mt-4 border -blue-400 border-blue-400" />
+          </div>
+        </div>
+
+        {/* 날짜로 보기  */}
+        <div>
+          <h2>날짜로 보기 </h2>
+        </div>
+
+        {/* 멤버 보기  */}
+
+        <div className="mt-8 mb-4 border-4 border-gray-100"></div>
+
+        <div className="m-4 mt-4">
+          <h2 className="mt-8 text-lg font-bold">
+            참석 멤버 <span className="font-normal">(6명 참여)</span>
+          </h2>
+
+          <div className="mt-4 p-4 w-full shadow-2xl rounded-xl">
+            <div className="grid grid-cols-2">
+              <div className="ml-4">
+                <h3 className="my-6 font-bold">
+                  가능해요 <span className="text-green-500">4</span>
+                </h3>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-red-200 w-8 h-8 mr-2 rounded-full">
+                    😺
+                  </div>
+                  <div className="h-4 w-4 -ml-5 -mb-4 rounded-full bg-moida"></div>
+                  <p className="ml-1 font-bold">소석진 (나)</p>
+                </div>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-yellow-200 w-8 h-8 mr-2 rounded-full">
+                    🎀
+                  </div>
+                  <p>하영이</p>
+                </div>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-yellow-300 w-8 h-8 mr-2 rounded-full">
+                    ⚽
+                  </div>
+                  <p>경후니</p>
+                </div>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-green-200 w-8 h-8 mr-2 rounded-full">
+                    🍩
+                  </div>
+                  <p>이혀니</p>
+                </div>
+              </div>
+
+              <div className="ml-4">
+                <h3 className="my-6 font-bold">
+                  불가능해요 <span className="text-red-500">2</span>
+                </h3>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-blue-300 w-8 h-8 mr-2 rounded-full">
+                    🌹
+                  </div>
+                  <p>람이</p>
+                </div>
+                <div className="flex items-center mb-4">
+                  <div className="flex justify-center items-center bg-indigo-400 w-8 h-8 mr-2 rounded-full">
+                    🥑
+                  </div>
+                  <p>서하서하</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default ResultDetail;

--- a/src/components/ui/organisms/BottomButton.jsx
+++ b/src/components/ui/organisms/BottomButton.jsx
@@ -4,7 +4,7 @@ function BottomButton(props) {
   const { onClick, children } = props;
   return (
     <button
-      className="flex justify-center items-center absolute bottom-0 left-0 text-center text-white h-16 w-screen bg-moida"
+      className="flex justify-center items-center fixed bottom-0 left-0 text-center text-white h-16 w-screen bg-moida"
       onClick={onClick}
     >
       <span className="flex justify-center items-center">{children}</span>

--- a/src/components/ui/organisms/Navbar.jsx
+++ b/src/components/ui/organisms/Navbar.jsx
@@ -23,7 +23,7 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
         <FaBars className="mx-3 h-full" onClick={showSidebar} />
       </div>
 
-      <hr className="mb-4" />
+      <hr className="" />
 
       <nav className={sidebar ? "nav-menu active z-50 nav-shadow" : "nav-menu"}>
         <ul className="nav-menu-items">

--- a/src/components/ui/organisms/Navbar.jsx
+++ b/src/components/ui/organisms/Navbar.jsx
@@ -20,7 +20,7 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
           <img className="h-full p-2" src="./images/Logo.png" alt="MOIDA" />
         </Link>
 
-        <FaBars className="mx-3 h-full" onClick={showSidebar} />
+        <FaBars className="mx-3 h-full cursor-pointer" onClick={showSidebar} />
       </div>
 
       <hr className="" />
@@ -28,7 +28,10 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
       <nav className={sidebar ? "nav-menu active z-50 nav-shadow" : "nav-menu"}>
         <ul className="nav-menu-items">
           <li className="flex w-full h-12 justify-end items-center">
-            <BsX onClick={showSidebar} className="mr-3 mt-2 text-3xl" />
+            <BsX
+              onClick={showSidebar}
+              className="mr-3 mt-2 text-3xl cursor-pointer"
+            />
           </li>
 
           <div className="m-8 mt-16">


### PR DESCRIPTION
resolved #59 

## Description

- 모임 일정 결과 페이지를 구현한다.

## Progress

- [x] 모임 일정 결과 페이지 간략히 보기 레이아웃
- [x] 결과 페이지 url 로 접근 처리
- [x] 모임 내용 상세보기 페이지

## Screenshot

![일정결과페이지](https://user-images.githubusercontent.com/53388557/130040692-df0c7614-0b0e-4764-9d2a-d8ddfc9b0318.gif)

## Comments

- 날짜,시간에서 정보 넘어오는 것 대비, 레이아웃은 일단 찍어놓음


